### PR TITLE
Add simple counter demo

### DIFF
--- a/demo/counter/counter-worker.js
+++ b/demo/counter/counter-worker.js
@@ -1,0 +1,25 @@
+import {
+  ClientStateMessenger,
+  MasterStateMessenger
+} from "../../lib/state-messenger/StateMessenger.js";
+
+const counterStateMessenger = MasterStateMessenger.create("counter");
+const actionStateMessenger = ClientStateMessenger.create("action");
+
+let counter = 0;
+
+actionStateMessenger.listen(action => {
+  if (action === "++") {
+    counter++;
+  } else if (action === "--") {
+    counter--;
+    // TODO(tvanderlippe): Remove this once the initialState for the master is optional.
+  } else if (action) {
+    throw new Error(`Received invalid counter action: ${action}`);
+  }
+
+  counterStateMessenger.setState(counter);
+});
+
+actionStateMessenger.start();
+counterStateMessenger.start();

--- a/demo/counter/index.html
+++ b/demo/counter/index.html
@@ -1,0 +1,68 @@
+<!--
+@license
+Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <meta name="theme-color" content="#392B33">
+  <title>StateMessenger counter demo</title>
+  <style>
+  html, body {
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  body {
+    background: #e2e2e2;
+  }
+
+  #counter {
+    text-align: center;
+  }
+
+  .actions {
+    display: flex;
+  }
+
+  .actions button {
+    flex: 1;
+  }
+  </style>
+</head>
+<body>
+  <h1>Counter</h1>
+  <div id="counter">0</div>
+  <div class="actions">
+    <button>++</button><button>--</button>
+  </div>
+  <script type="module">
+    import {ClientStateMessenger, MasterStateMessenger} from '../../lib/state-messenger/StateMessenger.js';
+
+    const worker = new Worker('./counter-worker.js', {type: 'module'});
+    const counter = document.getElementById('counter');
+    const counterStateMessenger = ClientStateMessenger.create('counter');
+    const actionStateMessenger = MasterStateMessenger.create('action');
+
+    counterStateMessenger.listen((newValue) => {
+      counter.textContent = newValue;
+    });
+    counterStateMessenger.start();
+
+    for (const button of document.getElementsByTagName('button')) {
+      button.addEventListener('click', () => {
+        actionStateMessenger.setState(button.textContent);
+      });
+    }
+    actionStateMessenger.start();
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "scripts": {
     "build": "tsc",
-    "format": "prettier --write \"{src/**/*.ts,*.{js,json,md}}\"",
-    "format-check": "test $(prettier --l \"{src/**/*.ts,*.{js,json,md}}\" | wc -l) -eq 0",
+    "format": "prettier --write \"{demo/**/*.js,src/**/*.ts,*.{js,json,md}}\"",
+    "format-check": "test $(prettier --l \"{demo/**/*.js,src/**/*.ts,*.{js,json,md}}\" | wc -l) -eq 0",
     "clean": "touch lib && rm -rf lib && mkdir lib",
     "test": "npm run clean && npm run build && karma start"
   },


### PR DESCRIPTION
You can open this demo on http://localhost:8000/demo/counter/ and push the buttons to increment/decrement the counter.

One thing I found is that the master should not send initialState if it was not provided. E.g. make the `initialState` optional for the master. I will do that in a separate PR.