### PR TITLE
Make initialState of the master optional

### DIFF
--- a/demo/counter/counter-worker.js
+++ b/demo/counter/counter-worker.js
@@ -13,8 +13,7 @@ actionStateMessenger.listen(action => {
     counter++;
   } else if (action === "--") {
     counter--;
-    // TODO(tvanderlippe): Remove this once the initialState for the master is optional.
-  } else if (action) {
+  } else {
     throw new Error(`Received invalid counter action: ${action}`);
   }
 

--- a/src/test/state-messenger/StateMessengerWorker.ts
+++ b/src/test/state-messenger/StateMessengerWorker.ts
@@ -1,6 +1,6 @@
 import { MasterStateMessenger } from "../../state-messenger/StateMessenger.js";
 
-const state = {
+const initialState = {
   foo: "",
   bar: { baz: 5 }
 };
@@ -9,11 +9,11 @@ const newState = {
   bar: { baz: 6 }
 };
 
-let master: MasterStateMessenger<{}>;
+let master: MasterStateMessenger<"channel">;
 
 onmessage = ({ data }) => {
   if (data === "create") {
-    master = MasterStateMessenger.create("channel", state);
+    master = MasterStateMessenger.create("channel", { initialState });
     master.start();
   } else if (data === "setState") {
     master.setState(newState);


### PR DESCRIPTION
I discovered this issue while working on the demo. Receiving `undefined` as action is annoying in the worker. Therefore, make it optional.

To make TypeScript happy, I changed all `S` to `StateMessengerChannelMap[C]`. Creating messengers now has as generic the channel name, which I actually like. It is descriptive, as multiple channels could use the same type.